### PR TITLE
CodeQL - larger runner testing

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,8 +23,8 @@ env:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
-    #runs-on: securingdev-premium-runner
+    #runs-on: ubuntu-latest
+    runs-on: securingdev-premium-runner
     permissions:
       actions: read
       contents: read
@@ -63,5 +63,5 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
-      env:
-        CODEQL_EXTRACTOR_GO_MAX_GOROUTINES: 16
+      #env:
+      #  CODEQL_EXTRACTOR_GO_MAX_GOROUTINES: 16

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -63,5 +63,5 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
-      #env:
-      #  CODEQL_EXTRACTOR_GO_MAX_GOROUTINES: 16
+      env:
+        CODEQL_EXTRACTOR_GO_MAX_GOROUTINES: 16

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,8 +23,8 @@ on:
 jobs:
   analyze:
     name: Analyze
-    #runs-on: ubuntu-latest
-    runs-on: securingdev-premium-runner
+    runs-on: ubuntu-latest
+    #runs-on: securingdev-premium-runner
     permissions:
       actions: read
       contents: read
@@ -63,5 +63,5 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
-    #  env:
-    #    CODEQL_EXTRACTOR_GO_MAX_GOROUTINES: 16
+      env:
+        CODEQL_EXTRACTOR_GO_MAX_GOROUTINES: 8

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,8 +17,8 @@ on:
       - 'rfd/**'
   workflow_dispatch: 
   
-env:
-  CODEQL_EXTRACTOR_GO_BUILD_TRACING: on
+#env:
+#  CODEQL_EXTRACTOR_GO_BUILD_TRACING: on
 
 jobs:
   analyze:
@@ -57,11 +57,11 @@ jobs:
         languages: ${{ matrix.language }}
         debug: true
 
-    - name: Build
-      run: |
-        make full
+    #- name: Build
+    #  run: |
+    #    make full
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
-      env:
-        CODEQL_EXTRACTOR_GO_MAX_GOROUTINES: 16
+    #  env:
+    #    CODEQL_EXTRACTOR_GO_MAX_GOROUTINES: 16

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -64,4 +64,4 @@ jobs:
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
       env:
-        CODEQL_EXTRACTOR_GO_MAX_GOROUTINES: 8
+        CODEQL_EXTRACTOR_GO_MAX_GOROUTINES: 16


### PR DESCRIPTION
GO Build Timings

| Auto v Trace | Runner Size | Max GOROUTINES | Time | Files Scanned| 
|-----|---------|--|---------|-----|
| auto | 2core | 8 | [error](https://github.com/octodemo/teleport/runs/8281206826?check_suite_focus=true) | |
| auto | 64core | 8 | 19m46s|1025|
| auto | 64core | 16 | ||
| auto | 64core | (32) | 17m35s|1025|
| trace | 2core | 16 | 1h27m|804|
| trace | 64core | 16 |31m11s|955|
| trace | 64core | (32) |28m40s|955|

[AutoBuild Test2](https://github.com/octodemo/teleport/runs/8281206826?check_suite_focus=true)(error during autobuild)
- 2 core runner
- AutoBuild
- 8 limit on Go Routines (CODEQL_EXTRACTOR_GO_MAX_GOROUTINES: 8)


[Autobuild Baseline](https://github.com/octodemo/teleport/runs/8257012400?check_suite_focus=true) (19m46s + 1025 files)
- 64 core runner (this fails on 2core so we start here :D) 
- AutoBuild
- 8 limit on Go Routines (CODEQL_EXTRACTOR_GO_MAX_GOROUTINES: 8)

[Autobuild Test1](https://github.com/octodemo/teleport/runs/8278780228?check_suite_focus=true) (17m35s + 1025 files)
- 64 core runner
- AutoBuild
-  NO limit on Go Routines (#CODEQL_EXTRACTOR_GO_MAX_GOROUTINES)

[Autobuild Test3]() ( )
- 64 core runner
- AutoBuild
-  16 Go Routines (CODEQL_EXTRACTOR_GO_MAX_GOROUTINES: 16)

[GO BUILD TRACE Baseline](https://github.com/octodemo/teleport/runs/8258571361?check_suite_focus=true)(1h27m + 804 files)
- 2core runner
- Go Build Tracer (  CODEQL_EXTRACTOR_GO_BUILD_TRACING: on) + build `make full`
- 16 limit on Go Routines (CODEQL_EXTRACTOR_GO_MAX_GOROUTINES: 16)

[GO BUILD TRACE - Test 2](https://github.com/octodemo/teleport/runs/8277480208?check_suite_focus=true) (31m11s + 955files)
- 64 core runner
- Go Build Tracer (  CODEQL_EXTRACTOR_GO_BUILD_TRACING: on) + build `make full`
- 16 limit on Go Routines (CODEQL_EXTRACTOR_GO_MAX_GOROUTINES: 16)

[GO BUILD TRACE - Test 1](https://github.com/octodemo/teleport/runs/8270690491?check_suite_focus=true) (28m40s + 955 files)
- 64 core runner
- Go Build Tracer (  CODEQL_EXTRACTOR_GO_BUILD_TRACING: on) + build `make full`
- No limit on Go Routines (#CODEQL_EXTRACTOR_GO_MAX_GOROUTINES)

